### PR TITLE
Mise à jour package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     },
     "dependencies": {
         "@smallprod/models": "^4.4.11",
-        "bcrypt": "^5.0.0",
+        "bcrypt": "^6.0.0",
         "body-parser": "^1.19.0",
         "cookie-parser": "^1.4.5",
         "crypto": "^1.0.1",


### PR DESCRIPTION
Je propose de passer à la version 6 de bcrypt pour des raisons de sécurité